### PR TITLE
Added affine matrix operations on math.h

### DIFF
--- a/Source/Base/Base/Math/Math.h
+++ b/Source/Base/Base/Math/Math.h
@@ -184,4 +184,57 @@ namespace Math
         bool result = componentA || componentB || componentC;
         return result;
     }
+
+    //Multiply 2 affine matrices as if they were mat4x4 matrices
+    inline mat4a MuliplyAffine(const mat4a& m1, const mat4a& m2)
+    {
+        return mat4a(
+            m1[0][0] * m2[0][0] + m1[1][0] * m2[0][1] + m1[2][0] * m2[0][2],
+            m1[0][1] * m2[0][0] + m1[1][1] * m2[0][1] + m1[2][1] * m2[0][2],
+            m1[0][2] * m2[0][0] + m1[1][2] * m2[0][1] + m1[2][2] * m2[0][2],
+
+            m1[0][0] * m2[1][0] + m1[1][0] * m2[1][1] + m1[2][0] * m2[1][2],
+            m1[0][1] * m2[1][0] + m1[1][1] * m2[1][1] + m1[2][1] * m2[1][2],
+            m1[0][2] * m2[1][0] + m1[1][2] * m2[1][1] + m1[2][2] * m2[1][2],
+
+            m1[0][0] * m2[2][0] + m1[1][0] * m2[2][1] + m1[2][0] * m2[2][2],
+            m1[0][1] * m2[2][0] + m1[1][1] * m2[2][1] + m1[2][1] * m2[2][2],
+            m1[0][2] * m2[2][0] + m1[1][2] * m2[2][1] + m1[2][2] * m2[2][2],
+
+            m1[0][0] * m2[3][0] + m1[1][0] * m2[3][1] + m1[2][0] * m2[3][2] + m1[3][0],
+            m1[0][1] * m2[3][0] + m1[1][1] * m2[3][1] + m1[2][1] * m2[3][2] + m1[3][1],
+            m1[0][2] * m2[3][0] + m1[1][2] * m2[3][1] + m1[2][2] * m2[3][2] + m1[3][2]);
+    }
+
+    //apply a scale vector to an affine matrix. equivalent to multiplying the matrix by a scale diagonal matrix
+    inline mat4a ScaleAffine(const mat4a& m1, const vec3& m2)
+    { 
+        return mat4a(
+            m1[0][0] * m2.x,
+            m1[0][1] * m2.x,
+            m1[0][2] * m2.x,
+
+            m1[1][0] * m2.y,
+            m1[1][1] * m2.y,
+            m1[1][2] * m2.y,
+
+            m1[2][0] * m2.z,
+            m1[2][1] * m2.z,
+            m1[2][2] * m2.z,
+
+            m1[3][0],
+            m1[3][1],
+            m1[3][2]);
+    }
+
+    //create a 4x3 affine transform matrix from components
+    inline mat4a AffineTransformMatrix(const vec3& position, const quat& rotation, const vec3& scale)
+    {
+        mat4a rotMatrix = glm::toMat3(rotation);
+
+        mat4a translateMatrix = mat4a{ 1.f };
+        translateMatrix[3] = position;
+
+        return MuliplyAffine(translateMatrix, ScaleAffine(rotMatrix, scale));
+    }
 };

--- a/Source/Base/Base/Math/Math.h
+++ b/Source/Base/Base/Math/Math.h
@@ -185,8 +185,8 @@ namespace Math
         return result;
     }
 
-    namespace AffineMatrix {
-
+    namespace AffineMatrix
+    {
         //Multiply 2 affine matrices as if they were mat4x4 matrices
         inline mat4a MatrixMul(const mat4a& m1, const mat4a& m2)
         {

--- a/Source/Base/Base/Math/Math.h
+++ b/Source/Base/Base/Math/Math.h
@@ -185,56 +185,59 @@ namespace Math
         return result;
     }
 
-    //Multiply 2 affine matrices as if they were mat4x4 matrices
-    inline mat4a MuliplyAffine(const mat4a& m1, const mat4a& m2)
-    {
-        return mat4a(
-            m1[0][0] * m2[0][0] + m1[1][0] * m2[0][1] + m1[2][0] * m2[0][2],
-            m1[0][1] * m2[0][0] + m1[1][1] * m2[0][1] + m1[2][1] * m2[0][2],
-            m1[0][2] * m2[0][0] + m1[1][2] * m2[0][1] + m1[2][2] * m2[0][2],
+    namespace AffineMatrix {
 
-            m1[0][0] * m2[1][0] + m1[1][0] * m2[1][1] + m1[2][0] * m2[1][2],
-            m1[0][1] * m2[1][0] + m1[1][1] * m2[1][1] + m1[2][1] * m2[1][2],
-            m1[0][2] * m2[1][0] + m1[1][2] * m2[1][1] + m1[2][2] * m2[1][2],
+        //Multiply 2 affine matrices as if they were mat4x4 matrices
+        inline mat4a MatrixMul(const mat4a& m1, const mat4a& m2)
+        {
+            return mat4a(
+                m1[0][0] * m2[0][0] + m1[1][0] * m2[0][1] + m1[2][0] * m2[0][2],
+                m1[0][1] * m2[0][0] + m1[1][1] * m2[0][1] + m1[2][1] * m2[0][2],
+                m1[0][2] * m2[0][0] + m1[1][2] * m2[0][1] + m1[2][2] * m2[0][2],
 
-            m1[0][0] * m2[2][0] + m1[1][0] * m2[2][1] + m1[2][0] * m2[2][2],
-            m1[0][1] * m2[2][0] + m1[1][1] * m2[2][1] + m1[2][1] * m2[2][2],
-            m1[0][2] * m2[2][0] + m1[1][2] * m2[2][1] + m1[2][2] * m2[2][2],
+                m1[0][0] * m2[1][0] + m1[1][0] * m2[1][1] + m1[2][0] * m2[1][2],
+                m1[0][1] * m2[1][0] + m1[1][1] * m2[1][1] + m1[2][1] * m2[1][2],
+                m1[0][2] * m2[1][0] + m1[1][2] * m2[1][1] + m1[2][2] * m2[1][2],
 
-            m1[0][0] * m2[3][0] + m1[1][0] * m2[3][1] + m1[2][0] * m2[3][2] + m1[3][0],
-            m1[0][1] * m2[3][0] + m1[1][1] * m2[3][1] + m1[2][1] * m2[3][2] + m1[3][1],
-            m1[0][2] * m2[3][0] + m1[1][2] * m2[3][1] + m1[2][2] * m2[3][2] + m1[3][2]);
-    }
+                m1[0][0] * m2[2][0] + m1[1][0] * m2[2][1] + m1[2][0] * m2[2][2],
+                m1[0][1] * m2[2][0] + m1[1][1] * m2[2][1] + m1[2][1] * m2[2][2],
+                m1[0][2] * m2[2][0] + m1[1][2] * m2[2][1] + m1[2][2] * m2[2][2],
 
-    //apply a scale vector to an affine matrix. equivalent to multiplying the matrix by a scale diagonal matrix
-    inline mat4a ScaleAffine(const mat4a& m1, const vec3& m2)
-    { 
-        return mat4a(
-            m1[0][0] * m2.x,
-            m1[0][1] * m2.x,
-            m1[0][2] * m2.x,
+                m1[0][0] * m2[3][0] + m1[1][0] * m2[3][1] + m1[2][0] * m2[3][2] + m1[3][0],
+                m1[0][1] * m2[3][0] + m1[1][1] * m2[3][1] + m1[2][1] * m2[3][2] + m1[3][1],
+                m1[0][2] * m2[3][0] + m1[1][2] * m2[3][1] + m1[2][2] * m2[3][2] + m1[3][2]);
+        }
 
-            m1[1][0] * m2.y,
-            m1[1][1] * m2.y,
-            m1[1][2] * m2.y,
+        //apply a scale vector to an affine matrix. equivalent to multiplying the matrix by a scale diagonal matrix
+        inline mat4a ScaleMatrix(const mat4a& m1, const vec3& m2)
+        {
+            return mat4a(
+                m1[0][0] * m2.x,
+                m1[0][1] * m2.x,
+                m1[0][2] * m2.x,
 
-            m1[2][0] * m2.z,
-            m1[2][1] * m2.z,
-            m1[2][2] * m2.z,
+                m1[1][0] * m2.y,
+                m1[1][1] * m2.y,
+                m1[1][2] * m2.y,
 
-            m1[3][0],
-            m1[3][1],
-            m1[3][2]);
-    }
+                m1[2][0] * m2.z,
+                m1[2][1] * m2.z,
+                m1[2][2] * m2.z,
 
-    //create a 4x3 affine transform matrix from components
-    inline mat4a AffineTransformMatrix(const vec3& position, const quat& rotation, const vec3& scale)
-    {
-        mat4a rotMatrix = glm::toMat3(rotation);
+                m1[3][0],
+                m1[3][1],
+                m1[3][2]);
+        }
 
-        mat4a translateMatrix = mat4a{ 1.f };
-        translateMatrix[3] = position;
+        //create a 4x3 affine transform matrix from components
+        inline mat4a TransformMatrix(const vec3& position, const quat& rotation, const vec3& scale)
+        {
+            mat4a rotMatrix = glm::toMat3(rotation);
 
-        return MuliplyAffine(translateMatrix, ScaleAffine(rotMatrix, scale));
+            mat4a translateMatrix = mat4a{ 1.f };
+            translateMatrix[3] = position;
+
+            return MatrixMul(translateMatrix, ScaleMatrix(rotMatrix, scale));
+        }
     }
 };

--- a/Source/Base/Base/Types.h
+++ b/Source/Base/Base/Types.h
@@ -37,6 +37,7 @@ using uvec4 = glm::uvec4;
 using hvec4 = glm::vec<4, f16>;
 using mat3x3 = glm::mat3x3;
 using mat4x4 = glm::mat4x4;
+using mat4a = glm::mat4x3;
 using quat = glm::quat;
 
 #define DECLARE_GENERIC_BITWISE_OPERATORS(T) inline const T operator~ (T a) { return (T)~(i32)a; } \


### PR DESCRIPTION
GLM does not have actual affine matrix operations which are useful for a more efficient transform system. This PR adds mat4a as a type on novustypes for an alias to glm::mat4x3, and implements a few functions useful when dealing with affine matrices such as multiplying, scaling by vector, and efficiently creating a transform matrix