### PR TITLE
Cvar Settings Fix void to_json

### DIFF
--- a/Source/Base/Base/Util/JsonUtils.cpp
+++ b/Source/Base/Base/Util/JsonUtils.cpp
@@ -8,7 +8,7 @@ namespace glm
 {
 	void to_json(nlohmann::json& j, const vec4& P) 
 	{
-		j = { { "x", P.x }, { "y", P.y }, { "z", P.w }, { "w", P.z } };
+		j = { { "x", P.x }, { "y", P.y }, { "z", P.z }, { "w", P.w } };
 	};
 
 	void from_json(const nlohmann::json& j, vec4& P) 
@@ -21,7 +21,7 @@ namespace glm
 
 	void to_json(nlohmann::json& j, const ivec4& P) 
 	{
-		j = { { "x", P.x }, { "y", P.y }, { "z", P.w }, { "w", P.z } };
+		j = { { "x", P.x }, { "y", P.y }, { "z", P.z }, { "w", P.w } };
 	};
 
 	void from_json(const nlohmann::json& j, ivec4& P) 
@@ -564,6 +564,11 @@ namespace JsonUtils
 				}
 
 				config[parameter->name] = object;
+
+				if (object["initial"] == "camera.fogColor")
+				{
+					printf("type: %f\n", object["type"]);
+				}
 			}
 		}
 	}

--- a/Source/Base/Base/Util/JsonUtils.cpp
+++ b/Source/Base/Base/Util/JsonUtils.cpp
@@ -564,11 +564,6 @@ namespace JsonUtils
 				}
 
 				config[parameter->name] = object;
-
-				if (object["initial"] == "camera.fogColor")
-				{
-					printf("type: %f\n", object["type"]);
-				}
 			}
 		}
 	}


### PR DESCRIPTION
z and w were flipped in the to_json functions for the vec4 and ivec4. This commit fixes that.