### PR TITLE
Switch to modular actions for builds

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,8 +1,7 @@
-name: linux-build
+name: Linux Build
 
 on:
-  push:
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   linux-build:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -1,0 +1,12 @@
+name: Build
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  call-windows-build:
+    uses: ./.github/workflows/win-build.yml
+
+  call-linux-build:
+    uses: ./.github/workflows/linux-build.yml

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   call-windows-build:
+    name: Windows Build
     uses: ./.github/workflows/win-build.yml
 
   call-linux-build:
+    name: Linux Build
     uses: ./.github/workflows/linux-build.yml

--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -1,8 +1,7 @@
-name: win-build
+name: Windows Build
 
 on:
-  push:
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   win-build:

--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -6,8 +6,10 @@ on:
 jobs:
   win-build:
     runs-on: self-hosted
+    
     strategy:
       fail-fast: false
+      
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
This will allow us to re-use workflows in separate hook workflows