### PR TITLE
Add premake dependency caching

### DIFF
--- a/Dependencies/dxcompiler/dxcompiler.lua
+++ b/Dependencies/dxcompiler/dxcompiler.lua
@@ -16,6 +16,3 @@ Solution.Util.CreateDep(dep.Name, dep.Dependencies, function()
     Solution.Util.SetLinks(lib)
     Solution.Util.SetIncludes(dep.Path .. "/include")
 end)
-
-local libPath = iif(os.istarget("windows"), dep.Path .. "/lib/windows/dxcompiler.dll", dep.Path .. "/lib/linux/libdxcompiler.so")
-BuildSettings:Add("DXCompiler Dynamic Lib Path", libPath)

--- a/Dependencies/dxcompiler/dxcompiler.lua
+++ b/Dependencies/dxcompiler/dxcompiler.lua
@@ -1,13 +1,21 @@
-local mod = Solution.Util.CreateDepTable("dxcompiler", {})
+local dep = Solution.Util.CreateDepTable("dxcompiler", {})
 
-Solution.Util.CreateDep(mod.Name, mod.Dependencies, function()
-    Solution.Util.SetIncludes(mod.Path .. "/include")
+Solution.Util.CreateDep(dep.Name, dep.Dependencies, function()
+    local cachedData = Solution.Util.GetDepCache(dep, "cache")
     
-    local libPath = iif(os.istarget("windows"), mod.Path .. "/lib/windows", mod.Path .. "/lib/linux")
+    local libPath, lib
+    if cachedData then
+        libPath, lib = cachedData.libPaths, cachedData.libs
+    else
+        libPath = iif(os.istarget("windows"), dep.Path .. "/lib/windows", dep.Path .. "/lib/linux")
+        lib = iif(os.istarget("windows"), libPath .. "/dxcompiler.lib", libPath .. "/dxcompiler")
+        Solution.Util.SetDepCache(dep, "cache", { libPaths = libPath, libs = lib })
+    end
+    
     Solution.Util.SetLibDirs(libPath)
-    local link = iif(os.istarget("windows"), libPath .. "/dxcompiler.lib", libPath .. "/dxcompiler")
-    Solution.Util.SetLinks(link)
+    Solution.Util.SetLinks(lib)
+    Solution.Util.SetIncludes(dep.Path .. "/include")
 end)
 
-local libPath = iif(os.istarget("windows"), mod.Path .. "/lib/windows/dxcompiler.dll", mod.Path .. "/lib/linux/libdxcompiler.so")
+local libPath = iif(os.istarget("windows"), dep.Path .. "/lib/windows/dxcompiler.dll", dep.Path .. "/lib/linux/libdxcompiler.so")
 BuildSettings:Add("DXCompiler Dynamic Lib Path", libPath)

--- a/Dependencies/glfw/glfw.lua
+++ b/Dependencies/glfw/glfw.lua
@@ -1,14 +1,14 @@
 local dep = Solution.Util.CreateDepTable("Glfw", {})
 
 Solution.Util.CreateStaticLib(dep.Name, Solution.Projects.Current.BinDir, dep.Dependencies, function()
-    local defines = { "_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS", "_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS", "_CRT_SECURE_NO_WARNINGS" }
-
     Solution.Util.SetLanguage("C++")
     Solution.Util.SetCppDialect(20)
 
     local sourceDir = dep.Path .. "/src"
     local includeDir = dep.Path .. "/include"
-
+    
+    local defines = { "_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS", "_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS", "_CRT_SECURE_NO_WARNINGS" }
+    local links = {}
     local files =
     {
         includeDir .. "/GLFW/glfw3.h",
@@ -34,12 +34,9 @@ Solution.Util.CreateStaticLib(dep.Name, Solution.Projects.Current.BinDir, dep.De
         sourceDir .. "/null_window.c",
         sourceDir .. "/null_joystick.c",
     }
-    Solution.Util.SetFiles(files)
-    Solution.Util.SetIncludes(dep.Path)
-    Solution.Util.SetDefines(defines)
 
-    Solution.Util.SetFilter("platforms:Win64", function()
-        local files =
+    if os.target() == "windows" then
+        local platformFiles =
         {
             sourceDir .. "/win32_thread.h",
             sourceDir .. "/win32_time.h",
@@ -53,15 +50,10 @@ Solution.Util.CreateStaticLib(dep.Name, Solution.Projects.Current.BinDir, dep.De
             sourceDir .. "/win32_window.c",
             sourceDir .. "/wgl_context.c",
         }
-        
-        Solution.Util.SetFiles(files)
-        Solution.Util.SetDefines({ "_GLFW_WIN32" })
-    end)
-
-    Solution.Util.SetFilter("system:linux", function()
-        local useXorg, useWayland = BuildSettings:Get("Using X11"), BuildSettings:Get("Using Wayland")
-        
-        local files =
+        Solution.Util.MergeIntoTable(files, platformFiles)
+        Solution.Util.MergeIntoTable(defines, { "_GLFW_WIN32" } )
+    else
+        local platformFiles =
         {
             sourceDir .. "/posix_module.c",
             sourceDir .. "/posix_poll.c",
@@ -72,12 +64,12 @@ Solution.Util.CreateStaticLib(dep.Name, Solution.Projects.Current.BinDir, dep.De
             sourceDir .. "/linux_joystick.c",
             sourceDir .. "/xkb_unicode.c",
         }
+        Solution.Util.MergeIntoTable(files, platformFiles)
+        Solution.Util.MergeIntoTable(links, { "pthread" })
         
-        Solution.Util.SetFiles(files)
-        Solution.Util.SetLinks({ "pthread" })
-        
+        local useXorg, useWayland = BuildSettings:Get("Using X11"), BuildSettings:Get("Using Wayland")
         if(useXorg) then
-            local files = 
+            local platformFiles = 
             {
                 sourceDir .. "/x11_platform.h",
                 
@@ -85,13 +77,13 @@ Solution.Util.CreateStaticLib(dep.Name, Solution.Projects.Current.BinDir, dep.De
                 sourceDir .. "/x11_monitor.c",
                 sourceDir .. "/x11_window.c",
             }
-            Solution.Util.SetFiles(files)
-            Solution.Util.SetDefines({ "_GLFW_X11" })
-            Solution.Util.SetLinks({ "X11" })
+            Solution.Util.MergeIntoTable(files, platformFiles)
+            Solution.Util.MergeIntoTable(defines, { "_GLFW_X11" } )
+            Solution.Util.MergeIntoTable(links, { "X11" } )
         end
         
         if(useWayland and not useXorg) then
-            local files = 
+            local platformFiles = 
             {
                 sourceDir .. "/wl_platform.h",
                 
@@ -99,11 +91,16 @@ Solution.Util.CreateStaticLib(dep.Name, Solution.Projects.Current.BinDir, dep.De
                 sourceDir .. "/wl_monitor.c",
                 sourceDir .. "/wl_window.c",
             }
-            Solution.Util.SetFiles(files)
-            Solution.Util.SetDefines({ "_GLFW_WAYLAND" })
-            Solution.Util.SetLinks({ "wayland-dev" })
+            Solution.Util.MergeIntoTable(files, platformFiles)
+            Solution.Util.MergeIntoTable(defines, { "_GLFW_WAYLAND" } )
+            Solution.Util.MergeIntoTable(links, { "wayland-dev" } )
         end
-    end)
+    end
+    
+    Solution.Util.SetDefines(defines)
+    Solution.Util.SetLinks(links)
+    Solution.Util.SetFiles(files)
+    Solution.Util.SetIncludes(dep.Path)
 end)
 
 local function populateDepCache(dep)

--- a/Dependencies/glfw/glfw.lua
+++ b/Dependencies/glfw/glfw.lua
@@ -115,26 +115,23 @@ local function populateDepCache(dep)
         
         if os.target() == "windows" then
             -- add win32 defines
-            table.insert(def, "GLFW_EXPOSE_NATIVE_WIN32")
-            table.insert(def, "_GLFW_WIN32")
+            Solution.Util.MergeIntoTable(def, { "GLFW_EXPOSE_NATIVE_WIN32" })
+            Solution.Util.MergeIntoTable(link, { "_GLFW_WIN32" })
         else
             local useXorg, useWayland = BuildSettings:Get("Using X11"), BuildSettings:Get("Using Wayland")
-            
             if(useXorg) then
                 -- add x11 defines and libraries
-                table.insert(def, "GLFW_EXPOSE_NATIVE_X11")
-                table.insert(def, "_GLFW_X11")
-                table.insert(link, "X11")
+                Solution.Util.MergeIntoTable(def, { "GLFW_EXPOSE_NATIVE_X11", "_GLFW_X11" })
+                Solution.Util.MergeIntoTable(link, { "X11" })
             end
             
             if(useWayland and not useXorg) then
                 -- add wayland defines and libraries
-                table.insert(def, "GLFW_EXPOSE_NATIVE_WAYLAND")
-                table.insert(def, "_GLFW_WAYLAND")
-                table.insert(link, "wayland-dev")
+                Solution.Util.MergeIntoTable(def, { "GLFW_EXPOSE_NATIVE_WAYLAND", "_GLFW_WAYLAND" })
+                Solution.Util.MergeIntoTable(link, { "wayland-dev" })
             end
             
-            table.insert(link, "pthread")
+            Solution.Util.MergeIntoTable(link, { "pthread" })
         end
         cachedData = { defines = def, links = link }
         Solution.Util.SetDepCache(dep, "cache", cachedData)

--- a/Dependencies/glfw/glfw.lua
+++ b/Dependencies/glfw/glfw.lua
@@ -115,8 +115,7 @@ local function populateDepCache(dep)
         
         if os.target() == "windows" then
             -- add win32 defines
-            Solution.Util.MergeIntoTable(def, { "GLFW_EXPOSE_NATIVE_WIN32" })
-            Solution.Util.MergeIntoTable(link, { "_GLFW_WIN32" })
+            Solution.Util.MergeIntoTable(def, { "GLFW_EXPOSE_NATIVE_WIN32", "_GLFW_WIN32" })
         else
             local useXorg, useWayland = BuildSettings:Get("Using X11"), BuildSettings:Get("Using Wayland")
             if(useXorg) then

--- a/Dependencies/vulkan/vulkan.lua
+++ b/Dependencies/vulkan/vulkan.lua
@@ -2,8 +2,7 @@ local function getVulkanInfo()
     local envName = "VULKAN_SDK"
     local includeDirs = {}
     local libs = {}
-
-    -- Check if environment variable exists
+    
     local vulkanSDK = os.getenv(envName)
     if not vulkanSDK then
         Solution.Util.PrintError("Failed to find Vulkan SDK with system variable '" .. envName .. "'. Please ensure Vulkan is installed and configured properly")
@@ -25,7 +24,16 @@ end
 local dep = Solution.Util.CreateDepTable("vulkan", {})
 
 Solution.Util.CreateDep(dep.Name, dep.Dependencies, function()
-    local includeDirs, libs = getVulkanInfo()
+    local cachedData = Solution.Util.GetDepCache(dep, "cache")
+
+    local includeDirs, libs
+    if cachedData then
+        includeDirs, libs = cachedData.includes, cachedData.libs
+    else
+        includeDirs, libs = getVulkanInfo()
+        Solution.Util.SetDepCache(dep, "cache", { includes = includeDirs, libs = libs })
+    end
+
     Solution.Util.SetIncludes(includeDirs)
     Solution.Util.SetLinks(libs)
     Solution.Util.SetDefines({ "_CRT_SECURE_NO_WARNINGS" })

--- a/Premake/ProjectUtil.lua
+++ b/Premake/ProjectUtil.lua
@@ -97,13 +97,23 @@ Solution.Util.CreateDepTable = function(name, dependencies)
     return dependency
 end
 
+Solution.Util.GetDepTable = function(depName)
+    local depInternalName = "Dependency-" .. depName
+    local dep = _G[depInternalName]
+    if (dep == nil) then
+        Solution.Util.PrintError("Tried to fetch undeclared dependency '" .. depName .. "'")
+    end
+    
+    return dep
+end
+
 -- Cache a value inside the dep table
-function Solution.Util.SetDepCache(dep, key, data)
+Solution.Util.SetDepCache = function(dep, key, data)
     dep.Cache[key] = data
 end
 
 -- Retrieve a cached value from the dep table, or return nil if not cached
-function Solution.Util.GetDepCache(dep, key)
+Solution.Util.GetDepCache = function(dep, key)
     if dep.Cache[key] then
         return dep.Cache[key]
     end

--- a/Premake/ProjectUtil.lua
+++ b/Premake/ProjectUtil.lua
@@ -431,6 +431,12 @@ Solution.Util.ClearFilter = function()
     filter { }
 end
 
+Solution.Util.MergeIntoTable = function(t, x)
+    for _, v in pairs(x) do
+        table.insert(t, v)
+    end
+end
+
 if InitBuildSettings == nil then
     function InitBuildSettings(silentFailOnDuplicateSetting)
         if BuildSettings == nil then

--- a/Premake/ProjectUtil.lua
+++ b/Premake/ProjectUtil.lua
@@ -88,13 +88,27 @@ Solution.Util.CreateModuleTable = function(name, dependencies)
 end
 
 Solution.Util.CreateDepTable = function(name, dependencies)
-    local dependency = { Name = name }
+    local dependency = { Name = name, Cache = {} }
 
     dependency.NameLow = string.lower(dependency.Name)
     dependency.Path = path.getabsolute(dependency.NameLow .. "/", Solution.Projects.Current.DependencyDir)
     dependency.Dependencies = dependencies
 
     return dependency
+end
+
+-- Cache a value inside the dep table
+function Solution.Util.SetDepCache(dep, key, data)
+    dep.Cache[key] = data
+end
+
+-- Retrieve a cached value from the dep table, or return nil if not cached
+function Solution.Util.GetDepCache(dep, key)
+    if dep.Cache[key] then
+        return dep.Cache[key]
+    end
+    
+    return nil
 end
 
 Solution.Util.IncludeSubmodule = function(name, rootDir, binDir)

--- a/Premake/ProjectUtil.lua
+++ b/Premake/ProjectUtil.lua
@@ -319,7 +319,8 @@ Solution.Util.CreateDep = function(name, dependencies, callback)
     local dependencyTable = 
     {
         Callback = callback,
-        Dependencies = dependencies
+        Dependencies = dependencies,
+        Cache = {}
     }
 
     _G[internalName] = dependencyTable


### PR DESCRIPTION
New helper functions and premake script rewrites to re-use already resolved platform-specific data in dependency inclusion.