### PR TITLE
Add physical and logical core count support

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -23,7 +23,7 @@ jobs:
 
 #    - name: Install dependencies
 #      run: |
-#        sudo apt-get update && sudo apt-get install -yq clang libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev libvulkan-dev
+#        sudo apt-get update && sudo apt-get install -yq clang libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev libvulkan-dev hwloc libhwloc-dev
 #        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 100
 
 #    - name: Install Vulkan SDK

--- a/Dependencies/Dependencies.lua
+++ b/Dependencies/Dependencies.lua
@@ -23,7 +23,8 @@ local dependencies =
     "utfcpp/utfcpp.lua",
     "luau/luau.lua",
     "quill/quill.lua",
-    "asio/asio.lua"
+    "asio/asio.lua",
+    "hwloc/hwloc.lua"
 }
 
 for k,v in pairs(dependencies) do

--- a/Dependencies/hwloc/hwloc.lua
+++ b/Dependencies/hwloc/hwloc.lua
@@ -1,0 +1,8 @@
+local dep = Solution.Util.CreateDepTable("hwloc", {})
+
+Solution.Util.CreateDep(dep.Name, dep.Dependencies, function()
+    if os.target() == "linux" then
+        Solution.Util.SetIncludes({ "/usr/include/hwloc" })
+        Solution.Util.SetLinks({ "hwloc" })
+    end
+end)

--- a/Source/Base/Base.lua
+++ b/Source/Base/Base.lua
@@ -1,4 +1,4 @@
-local mod = Solution.Util.CreateModuleTable("Base", { "glm", "robinhood", "json", "refl-cpp", "quill" })
+local mod = Solution.Util.CreateModuleTable("Base", { "glm", "robinhood", "json", "refl-cpp", "quill", "hwloc" })
 
 Solution.Util.CreateStaticLib(mod.Name, Solution.Projects.Current.BinDir, mod.Dependencies, function()
     local defines = { "_CRT_SECURE_NO_WARNINGS", "_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS", "_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS" }

--- a/Source/Base/Base/Util/CPUInfo.cpp
+++ b/Source/Base/Base/Util/CPUInfo.cpp
@@ -52,6 +52,8 @@ CPUInfo& CPUInfo::Get()
 
 void CPUInfo::Print(i32 detailLevel)
 {
+    NC_LOG_INFO("[CPUInfo]: Physical cores: {0}", _numCores);
+    NC_LOG_INFO("[CPUInfo]: Logical cores: {0}", _numThreads);
     if (detailLevel > 0)
     {
         NC_LOG_INFO("[CPUInfo]: {0}", _prettyName);

--- a/Source/Base/Base/Util/CPUInfo.cpp
+++ b/Source/Base/Base/Util/CPUInfo.cpp
@@ -7,8 +7,7 @@
 #include <windows.h>
 #else
 #include <stdint.h>
-#include <unistd.h>
-//#include <hwloc.h>
+#include <hwloc.h>
 #endif
 
 using namespace std;
@@ -138,23 +137,23 @@ CPUInfo::CPUInfo()
     _numThreads = static_cast<i32>(sysinfo.dwNumberOfProcessors);
 #else
     // init hwloc topology
-    //hwloc_topology_t topology;
-    //hwloc_topology_init(&topology);
-    //hwloc_topology_load(topology);
+    hwloc_topology_t topology;
+    hwloc_topology_init(&topology);
+    hwloc_topology_load(topology);
 
     // get the number of physical cores
-    //i32 num_physical_cores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
+    i32 num_physical_cores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
 
     // get the number of logical cores
-    //i32 num_logical_cores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
+    i32 num_logical_cores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
 
     // deinit hwloc
-    //hwloc_topology_destroy(topology);
+    hwloc_topology_destroy(topology);
     
     // set physical cores
-    _numCores = sysconf(_SC_NPROCESSORS_ONLN); //num_physical_cores;
+    _numCores = num_physical_cores;
     // set logical cores
-    _numThreads = sysconf(_SC_NPROCESSORS_CONF); //num_logical_cores;
+    _numThreads = num_logical_cores;
 #endif
 
     // if set the amount of threads per core

--- a/Source/Base/Base/Util/CPUInfo.cpp
+++ b/Source/Base/Base/Util/CPUInfo.cpp
@@ -118,20 +118,20 @@ CPUInfo::CPUInfo()
     std::vector<uint8_t> buffer(bufferSize);
     GetLogicalProcessorInformationEx(RelationProcessorCore, reinterpret_cast<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*>(buffer.data()), &bufferSize);
 
-    i32 num_physical_cores = 0;
+    i32 numPhysicalCores = 0;
     auto* ptr = reinterpret_cast<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*>(buffer.data());
     while (bufferSize > 0)
     {
         if (ptr->Relationship == RelationProcessorCore)
         {
-            ++num_physical_cores;
+            ++numPhysicalCores;
         }
         bufferSize -= ptr->Size;
         ptr = reinterpret_cast<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX*>(reinterpret_cast<uint8_t*>(ptr) + ptr->Size);
     }
 
     // set physical cores
-    _numCores = num_physical_cores;
+    _numCores = numPhysicalCores;
 
     // set logical cores
     _numThreads = static_cast<i32>(sysinfo.dwNumberOfProcessors);
@@ -142,18 +142,18 @@ CPUInfo::CPUInfo()
     hwloc_topology_load(topology);
 
     // get the number of physical cores
-    i32 num_physical_cores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
+    i32 numPhysicalCores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_CORE);
 
     // get the number of logical cores
-    i32 num_logical_cores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
+    i32 numLogicalCores = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
 
     // deinit hwloc
     hwloc_topology_destroy(topology);
     
     // set physical cores
-    _numCores = num_physical_cores;
+    _numCores = numPhysicalCores;
     // set logical cores
-    _numThreads = num_logical_cores;
+    _numThreads = numLogicalCores;
 #endif
 
     // if set the amount of threads per core

--- a/Source/Base/Base/Util/CPUInfo.cpp
+++ b/Source/Base/Base/Util/CPUInfo.cpp
@@ -51,8 +51,6 @@ CPUInfo& CPUInfo::Get()
 
 void CPUInfo::Print(i32 detailLevel)
 {
-    NC_LOG_INFO("[CPUInfo]: Physical cores: {0}", _numCores);
-    NC_LOG_INFO("[CPUInfo]: Logical cores: {0}", _numThreads);
     if (detailLevel > 0)
     {
         NC_LOG_INFO("[CPUInfo]: {0}", _prettyName);

--- a/Source/Base/Base/Util/CPUInfo.h
+++ b/Source/Base/Base/Util/CPUInfo.h
@@ -22,6 +22,7 @@ public:
     bool IsSSE42() const { return features.isSSE42; }
     bool IsAVX() const { return features.isAVX; }
     bool IsAVX2() const { return features.isAVX2; }
+    bool isAVX512F() const { return features.isAVX512F; }
     bool IsHyperThreaded() const { return features.isHTT; }
 
     void Print(i32 detailLevel);
@@ -41,6 +42,7 @@ private:
     static const u32 SSE42_POS = 0x00100000;
     static const u32 AVX_POS = 0x10000000;
     static const u32 AVX2_POS = 0x00000020;
+    static const u32 AVX512F_POS = 0x00008000;
     static const u32 LVL_NUM = 0x000000FF;
     static const u32 LVL_TYPE = 0x0000FF00;
     static const u32 LVL_CORES = 0x0000FFFF;
@@ -64,6 +66,7 @@ private:
         u8 isSSE42 : 1;
         u8 isAVX : 1;
         u8 isAVX2 : 1;
+        u8 isAVX512F : 1;
     };
 
     Features features;


### PR DESCRIPTION
In reference to https://github.com/novusengine/Engine/pull/5

This supersedes the above PR, using native Windows sysinfo to determine the core count, and hwloc on Linux.

Adds hwloc as a new Linux dependency.