### PR TITLE
Improve Vulkan and Slang SDK discovery

### DIFF
--- a/Dependencies/slang/slang.lua
+++ b/Dependencies/slang/slang.lua
@@ -1,40 +1,125 @@
-local vkSdk = os.getenv("VULKAN_SDK")
-if not vkSdk then
-    Solution.Util.PrintError("VULKAN_SDK not found. Please ensure Vulkan SDK is installed.")
-end
+local function getSlangInfo()
+    if os.target() == "linux" then
+        local includeDirs = {}
+        local libDirs = {}
+        local runtimeLibraries = {}
 
--- Determine platform-specific library paths
-local libName, libSrcPath
-if os.target() == "windows" then
-    libName = "slang.dll"
-    libSrcPath = vkSdk .. "/bin/" .. libName
-else
-    libName = "libslang.so"
-    libSrcPath = vkSdk .. "/lib/" .. libName
-end
+        if os.host() == "linux" then
+            local slangSDK = os.getenv("SLANG_SDK") or os.getenv("VULKAN_SDK")
+            local includeDir
+            local libDir
 
--- Copy shared library (release version always) during premake generation
-local binDir = Solution.Projects.Current.BinDir
-local configs = { "Debug", "RelDebug", "Release" }
+            if slangSDK then
+                includeDir = slangSDK .. "/include"
+                libDir = slangSDK .. "/lib"
 
-for _, cfg in ipairs(configs) do
-    local destDir = binDir .. "/" .. cfg
-    os.mkdir(destDir)
-    
-    local destPath = destDir .. "/" .. libName
-    local success, err = os.copyfile(libSrcPath, destPath)
-    if success then
-        Solution.Util.Print("Copied " .. libName .. " to " .. destDir)
+                if not os.isfile(includeDir .. "/slang/slang.h") then
+                    Solution.Util.PrintError(
+                        "The configured SDK does not contain Slang headers: '" .. includeDir .. "'."
+                    )
+                end
+
+                if not os.isfile(libDir .. "/libslang.so") then
+                    Solution.Util.PrintError(
+                        "The configured SDK does not contain the Slang library: '" .. libDir .. "'."
+                    )
+                end
+            else
+                includeDir = os.findheader("slang/slang.h")
+                libDir = os.findlib("slang")
+            end
+
+            if not includeDir then
+                Solution.Util.PrintError(
+                    "Failed to find the Slang headers in the system include paths. " ..
+                    "Source the Vulkan SDK's setup-env.sh, set SLANG_SDK, or install Slang system-wide."
+                )
+            end
+
+            if not libDir then
+                Solution.Util.PrintError(
+                    "Failed to find the Slang shared library in the system library paths. " ..
+                    "Source the Vulkan SDK's setup-env.sh, set SLANG_SDK, or install Slang system-wide."
+                )
+            end
+
+            table.insert(includeDirs, includeDir)
+            table.insert(libDirs, libDir)
+
+            if slangSDK then
+                runtimeLibraries = os.matchfiles(libDir .. "/libslang*.so*")
+            end
+        end
+
+        -- Requiring slang/slang.h distinguishes Shader Slang from the unrelated
+        -- S-Lang terminal library commonly installed by Linux distributions.
+        return {
+            includeDirs = includeDirs,
+            libDirs = libDirs,
+            runtimeLibraries = runtimeLibraries
+        }
+    end
+
+    -- Newer Vulkan SDKs bundle Slang. SLANG_SDK also permits a standalone Slang
+    -- installation without forcing Vulkan and Slang to share an SDK root.
+    local slangSDK = os.getenv("SLANG_SDK") or os.getenv("VULKAN_SDK")
+    if not slangSDK then
+        Solution.Util.PrintError(
+            "Failed to find Slang. Please set SLANG_SDK to the Slang SDK root, " ..
+            "or VULKAN_SDK when using a Vulkan SDK that bundles Slang."
+        )
+    end
+
+    local runtimeLibraries
+    if os.target() == "windows" then
+        runtimeLibraries = { slangSDK .. "/bin/slang.dll" }
     else
-        Solution.Util.PrintError("Failed to copy " .. libName .. ": " .. (err or "unknown error"))
+        runtimeLibraries = os.matchfiles(slangSDK .. "/lib/libslang*.so*")
+    end
+
+    return {
+        includeDirs = { slangSDK .. "/include" },
+        libDirs = { slangSDK .. "/lib" },
+        runtimeLibraries = runtimeLibraries
+    }
+end
+
+local function copyRuntimeLibraries(runtimeLibraries)
+    if not runtimeLibraries or #runtimeLibraries == 0 then
+        return
+    end
+
+    local binDir = Solution.Projects.Current.BinDir
+    local configs = { "Debug", "RelDebug", "Release" }
+
+    for _, runtimeLibrary in ipairs(runtimeLibraries) do
+        local runtimeLibraryName = path.getname(runtimeLibrary)
+
+        for _, cfg in ipairs(configs) do
+            local destDir = binDir .. "/" .. cfg
+            os.mkdir(destDir)
+
+            local destPath = destDir .. "/" .. runtimeLibraryName
+            local success, err = os.copyfile(runtimeLibrary, destPath)
+            if success then
+                Solution.Util.Print("Copied " .. runtimeLibraryName .. " to " .. destDir)
+            else
+                Solution.Util.PrintError(
+                    "Failed to copy " .. runtimeLibraryName .. " from '" .. runtimeLibrary .. "': " ..
+                    (err or "unknown error")
+                )
+            end
+        end
     end
 end
 
--- Create dependency
+local slangInfo = getSlangInfo()
+copyRuntimeLibraries(slangInfo.runtimeLibraries)
+
 local dep = Solution.Util.CreateDepTable("Slang-Slang", {})
 
 Solution.Util.CreateDep(dep.NameLow, dep.Dependencies, function()
-    Solution.Util.SetIncludes(vkSdk .. "/include")
-    Solution.Util.SetLibDirs(vkSdk .. "/lib")
+    Solution.Util.SetIncludes(slangInfo.includeDirs)
+    Solution.Util.SetLibDirs(slangInfo.libDirs)
     Solution.Util.SetLinks("slang")
 end)

--- a/Dependencies/vulkan/vulkan.lua
+++ b/Dependencies/vulkan/vulkan.lua
@@ -1,24 +1,73 @@
 local function getVulkanInfo()
-    local envName = "VULKAN_SDK"
     local includeDirs = {}
+    local libDirs = {}
     local libs = {}
-    
-    local vulkanSDK = os.getenv(envName)
-    if not vulkanSDK then
-        Solution.Util.PrintError("Failed to find Vulkan SDK with system variable '" .. envName .. "'. Please ensure Vulkan is installed and configured properly")
-    end
-    
-    -- Add Includes path
-    table.insert(includeDirs, vulkanSDK .. "/include")
-    
-    -- Add Library
-    if os.target() == "windows" then
-        table.insert(libs, vulkanSDK .. "/lib/vulkan-1.lib")
-    else
+
+    if os.target() == "linux" then
+        if os.host() == "linux" then
+            local vulkanSDK = os.getenv("VULKAN_SDK")
+            local includeDir
+            local libDir
+
+            if vulkanSDK then
+                includeDir = vulkanSDK .. "/include"
+                libDir = vulkanSDK .. "/lib/VulkanLoader/lib"
+
+                if not os.isfile(includeDir .. "/vulkan/vulkan.h") then
+                    Solution.Util.PrintError(
+                        "VULKAN_SDK does not contain Vulkan headers: '" .. includeDir .. "'."
+                    )
+                end
+
+                if not os.isfile(libDir .. "/libvulkan.so") then
+                    Solution.Util.PrintError(
+                        "VULKAN_SDK does not contain the Vulkan loader: '" .. libDir .. "'."
+                    )
+                end
+            else
+                includeDir = os.findheader("vulkan/vulkan.h")
+                libDir = os.findlib("vulkan")
+            end
+
+            if not includeDir then
+                Solution.Util.PrintError(
+                    "Failed to find the Vulkan headers in the system include paths. " ..
+                    "Source the Vulkan SDK's setup-env.sh, or install the Vulkan development packages."
+                )
+            end
+
+            if not libDir then
+                Solution.Util.PrintError(
+                    "Failed to find the Vulkan loader in the system library paths. " ..
+                    "Source the Vulkan SDK's setup-env.sh, or install the Vulkan development packages."
+                )
+            end
+
+            table.insert(includeDirs, includeDir)
+            table.insert(libDirs, libDir)
+        end
+
         table.insert(libs, "vulkan")
+    else
+        local envName = "VULKAN_SDK"
+        local vulkanSDK = os.getenv(envName)
+        if not vulkanSDK then
+            Solution.Util.PrintError(
+                "Failed to find the Vulkan SDK with system variable '" .. envName .. "'. " ..
+                "Please ensure Vulkan is installed and configured properly."
+            )
+        end
+
+        table.insert(includeDirs, vulkanSDK .. "/include")
+
+        if os.target() == "windows" then
+            table.insert(libs, vulkanSDK .. "/lib/vulkan-1.lib")
+        else
+            table.insert(libs, "vulkan")
+        end
     end
-    
-    return includeDirs, libs
+
+    return includeDirs, libDirs, libs
 end
 
 local dep = Solution.Util.CreateDepTable("vulkan", {})
@@ -26,15 +75,20 @@ local dep = Solution.Util.CreateDepTable("vulkan", {})
 Solution.Util.CreateDep(dep.Name, dep.Dependencies, function()
     local cachedData = Solution.Util.GetDepCache(dep.Name, "cache")
 
-    local includeDirs, libs
+    local includeDirs, libDirs, libs
     if cachedData then
-        includeDirs, libs = cachedData.includes, cachedData.libs
+        includeDirs, libDirs, libs = cachedData.includes, cachedData.libDirs, cachedData.libs
     else
-        includeDirs, libs = getVulkanInfo()
-        Solution.Util.SetDepCache(dep.Name, "cache", { includes = includeDirs, libs = libs })
+        includeDirs, libDirs, libs = getVulkanInfo()
+        Solution.Util.SetDepCache(dep.Name, "cache", {
+            includes = includeDirs,
+            libDirs = libDirs,
+            libs = libs
+        })
     end
 
     Solution.Util.SetIncludes(includeDirs)
+    Solution.Util.SetLibDirs(libDirs)
     Solution.Util.SetLinks(libs)
     Solution.Util.SetDefines({ "_CRT_SECURE_NO_WARNINGS" })
 end)

--- a/Premake/ProjectUtil.lua
+++ b/Premake/ProjectUtil.lua
@@ -237,6 +237,11 @@ Solution.Util.CreateProject = function(name, projectType, binDir, dependencies, 
         characterset ("ASCII")
         editandcontinue "Off"
 
+        filter "system:linux"
+            linkgroups "On"
+            linkoptions { "-Wl,-rpath,'$$ORIGIN'" }
+        filter {}
+
         filter "configurations:Debug"
             runtime "Debug"
             symbols "On"

--- a/Source/Filesystem/Filesystem/Core/File.cpp
+++ b/Source/Filesystem/Filesystem/Core/File.cpp
@@ -8,6 +8,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <thread>
 
 namespace fs = std::filesystem;
 

--- a/Source/Gameplay/Gameplay/Network/GameMessageRouter.h
+++ b/Source/Gameplay/Gameplay/Network/GameMessageRouter.h
@@ -60,7 +60,7 @@ namespace Network
         }
 
         template <PacketConcept PacketStruct>
-        void UnregisterPacketHandler(OpcodeType opcode)
+        void UnregisterPacketHandler(OpcodeType /*opcode*/)
         {
             auto opcode = static_cast<OpcodeType>(PacketStruct::PACKET_ID);
 

--- a/Source/Renderer/Renderer/Renderers/Vulkan/Backend/SpirvReflect.h
+++ b/Source/Renderer/Renderer/Renderers/Vulkan/Backend/SpirvReflect.h
@@ -33,7 +33,7 @@ VERSION HISTORY
 
 #define SPIRV_REFLECT_USE_SYSTEM_SPIRV_H
 #if defined(SPIRV_REFLECT_USE_SYSTEM_SPIRV_H)
-#include <spirv-headers/spirv.h>
+#include <spirv/unified1/spirv.h>
 #else
 #include "./include/spirv/unified1/spirv.h"
 #endif


### PR DESCRIPTION
## Summary

- prefer a sourced Vulkan tarball SDK on Linux and validate its header and loader layout
- retain system header/library discovery when no SDK environment is configured
- discover Slang through `SLANG_SDK` or the Vulkan SDK
- copy the complete versioned Slang runtime library set beside engine binaries

## Why

Ubuntu system packages split Vulkan and Slang across system paths, while the former LunarG apt SDK left Slang older than the engine-facing API. The official tarball keeps compatible Vulkan and Slang components together, but places the Vulkan loader in a separate SDK-relative directory.

## Validation

- clean Debug generation and full compile on the Ubuntu self-hosted runner using Vulkan SDK 1.4.357.1 and Slang 2026.13.1
- compiled the restored `SLANG_STAGE_DISPATCH` code without a compatibility bridge
- verified generated makefiles reference the tarball include, Slang library, and Vulkan loader directories
- verified `Engine-Tests` resolves the tarball Vulkan loader and bundled versioned Slang runtime library
