### PR TITLE
Fix slang global session leak in ShaderCooker

### DIFF
--- a/Source/ShaderCooker/ShaderCooker/ShaderCompiler.cpp
+++ b/Source/ShaderCooker/ShaderCooker/ShaderCompiler.cpp
@@ -258,6 +258,8 @@ namespace ShaderCooker
             }
             else if (_stageInfo.stage == Stage::COMPILATION)
             {
+                ShaderCooker::SlangBridge slangBridge(_sourceDirPath);
+
                 for (Shader& shader : _shaders)
                 {
                     if (!shader.hasResolvedIncludes)
@@ -268,8 +270,6 @@ namespace ShaderCooker
                         _shaderCache->Touch(shader.path);
                         continue;
                     }
-
-                    ShaderCooker::SlangBridge slangBridge(_sourceDirPath);
 
                     // Figure out the actual permutations
                     u32 numPermutationGroups = static_cast<u32>(shader.permutationGroups.size());

--- a/Source/ShaderCooker/ShaderCooker/SlangBridge.cpp
+++ b/Source/ShaderCooker/ShaderCooker/SlangBridge.cpp
@@ -39,7 +39,7 @@ namespace ShaderCooker
 
     SlangBridge::~SlangBridge()
     {
-        
+        delete static_cast<SlangBridgeData*>(_data);
     }
 
     void SlangBridge::AddDefine(const std::string& name, const std::string& value)


### PR DESCRIPTION
SlangBridge's destructor never freed its SlangBridgeData, leaking the slang global session it owns, and ShaderCompiler::Run constructed a new SlangBridge for every shader file - one leaked global session (each holding a compiled slang core module, ~160 MB) per shader. Cooking 65 shaders peaked at ~10.1 GiB RSS and climbed monotonically, OOMing the CI runner.

Delete the bridge data in the destructor and construct a single bridge above the shader loop; a global session is designed to be shared for a whole compilation run, and each redundant one was also recompiling the slang core module.

Measured on a full 65-shader force recook (Release, 16 threads): peak RSS 10.1 GiB -> 272 MB, wall time 24.0s -> 11.9s.